### PR TITLE
Añadir barra de acciones rápidas sticky para flujos principales del editor

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -9,6 +9,77 @@
  */
 
 /* =============================================
+   QUICK ACTIONS BAR
+   ============================================= */
+
+.quick-actions-bar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  flex: 1 1 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  margin-bottom: 8px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid #ececec;
+  border-radius: 12px;
+  backdrop-filter: blur(4px);
+}
+
+.quick-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid #ddd;
+  background: #fff;
+  color: #333;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.quick-action-btn:hover {
+  border-color: #ff6600;
+  color: #ff6600;
+  transform: translateY(-1px);
+}
+
+.quick-action-btn.active {
+  border-color: #ff6600;
+  color: #ff6600;
+  box-shadow: 0 2px 8px rgba(255, 102, 0, 0.2);
+}
+
+.quick-action-btn-primary {
+  background: #ff6600;
+  border-color: #ff6600;
+  color: #fff;
+}
+
+.quick-action-btn-primary:hover {
+  color: #fff;
+  background: #e55b00;
+  border-color: #e55b00;
+}
+
+.quick-action-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.quick-action-label-mobile {
+  display: none;
+}
+
+/* =============================================
    CANVAS CONTAINER
    ============================================= */
 
@@ -189,6 +260,28 @@
    ============================================= */
 
 @media (max-width: 768px) {
+  .quick-actions-bar {
+    justify-content: flex-start;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding: 8px;
+    gap: 8px;
+  }
+
+  .quick-action-btn {
+    flex: 0 0 auto;
+    font-size: 13px;
+    padding: 8px 10px;
+  }
+
+  .quick-action-label-desktop {
+    display: none;
+  }
+
+  .quick-action-label-mobile {
+    display: inline;
+  }
+
   #canvas-container {
     max-width: 100%;
     min-height: 250px;
@@ -211,6 +304,24 @@
 }
 
 @media (max-width: 480px) {
+  .quick-actions-bar {
+    top: 6px;
+    padding: 6px;
+    border-radius: 10px;
+  }
+
+  .quick-action-btn {
+    min-width: 84px;
+    padding: 7px 8px;
+    gap: 6px;
+    border-radius: 8px;
+    font-size: 12px;
+  }
+
+  .quick-action-icon {
+    font-size: 14px;
+  }
+
   #canvas-container {
     min-height: 200px;
     border-radius: 8px;

--- a/index.html
+++ b/index.html
@@ -32,6 +32,29 @@
     <div id="status-text"></div>
 
     <div class="workspace">
+      <div class="quick-actions-bar" id="quickActionsBar" aria-label="Acciones rápidas del editor">
+        <button id="quick-upload" class="quick-action-btn" type="button" title="Subir o reemplazar imagen">
+          <span class="quick-action-icon">🖼️</span>
+          <span class="quick-action-label quick-action-label-desktop">Subir/Reemplazar imagen</span>
+          <span class="quick-action-label quick-action-label-mobile">Subir</span>
+        </button>
+        <button id="quick-reset-filters" class="quick-action-btn" type="button" title="Resetear todos los filtros">
+          <span class="quick-action-icon">↺</span>
+          <span class="quick-action-label quick-action-label-desktop">Reset filtros</span>
+          <span class="quick-action-label quick-action-label-mobile">Reset</span>
+        </button>
+        <button id="quick-compare" class="quick-action-btn" type="button" title="Comparar imagen original y editada">
+          <span class="quick-action-icon">👁️</span>
+          <span class="quick-action-label quick-action-label-desktop">Comparar original</span>
+          <span class="quick-action-label quick-action-label-mobile">Comparar</span>
+        </button>
+        <button id="quick-download" class="quick-action-btn quick-action-btn-primary" type="button" title="Descargar imagen editada">
+          <span class="quick-action-icon">⬇️</span>
+          <span class="quick-action-label quick-action-label-desktop">Descargar</span>
+          <span class="quick-action-label quick-action-label-mobile">Guardar</span>
+        </button>
+      </div>
+
       <div class="canvas-panel">
         <!-- Canvas Container con placeholder -->
         <div id="canvas-container">

--- a/js/main.js
+++ b/js/main.js
@@ -22,6 +22,10 @@ let statusText;
 let placeholder;
 let canvasContainer;
 let editorControls;
+let quickUploadBtn;
+let quickResetFiltersBtn;
+let quickCompareBtn;
+let quickDownloadBtn;
 
 /**
  * Inicialización cuando el DOM está listo
@@ -114,6 +118,10 @@ function getDOMReferences() {
   placeholder = document.getElementById('placeholder');
   canvasContainer = document.getElementById('canvas-container');
   editorControls = document.getElementById('editorControls');
+  quickUploadBtn = document.getElementById('quick-upload');
+  quickResetFiltersBtn = document.getElementById('quick-reset-filters');
+  quickCompareBtn = document.getElementById('quick-compare');
+  quickDownloadBtn = document.getElementById('quick-download');
 }
 
 /**
@@ -137,6 +145,39 @@ function setupEventListeners() {
 
   // Listeners para recorte
   setupCropListeners();
+
+  // Listeners de acciones rápidas
+  setupQuickActionsListeners();
+}
+
+/**
+ * Configura la barra de acciones rápidas
+ */
+function setupQuickActionsListeners() {
+  if (quickUploadBtn) {
+    quickUploadBtn.addEventListener('click', () => {
+      fileInput?.click();
+    });
+  }
+
+  if (quickResetFiltersBtn) {
+    quickResetFiltersBtn.addEventListener('click', () => {
+      if (!canvasManager?.hasImage() || !uiControls) return;
+      uiControls.resetAllFilters();
+    });
+  }
+
+  if (quickCompareBtn) {
+    quickCompareBtn.addEventListener('click', () => {
+      const toggleComparisonBtn = document.getElementById('toggle-comparison');
+      if (!toggleComparisonBtn) return;
+      toggleComparisonBtn.click();
+    });
+  }
+
+  if (quickDownloadBtn) {
+    quickDownloadBtn.addEventListener('click', handleDownload);
+  }
 }
 
 /**
@@ -342,6 +383,7 @@ function setupComparisonListeners() {
         toggleBtn.classList.add('active');
         toggleBtn.querySelector('.btn-text').textContent = 'Ver Editada';
         canvasContainer.classList.add('comparing');
+        quickCompareBtn?.classList.add('active');
 
         // Mostrar controles de split view
         if (splitViewControl) {
@@ -352,6 +394,7 @@ function setupComparisonListeners() {
         toggleBtn.querySelector('.btn-text').textContent = 'Ver Original';
         canvasContainer.classList.remove('comparing');
         canvasContainer.classList.remove('split-view');
+        quickCompareBtn?.classList.remove('active');
 
         // Ocultar controles de split view
         if (splitViewControl) {
@@ -670,6 +713,7 @@ function handleClearImage() {
     toggleBtn.classList.remove('active');
     toggleBtn.querySelector('.btn-text').textContent = 'Ver Original';
   }
+  quickCompareBtn?.classList.remove('active');
 
   // Resetear UI del recorte
   exitCropMode();


### PR DESCRIPTION
### Motivation
- Reducir pasos y hacer los flujos más directos y visibles para usuarios nuevos colocando accesos rápidos cerca de la parte superior del workspace.
- Mejorar descubrimiento de operaciones frecuentes: subir/replace, reset filtros, comparar y descargar.

### Description
- Agregada la barra `quick-actions-bar` en `index.html` con cuatro botones: `#quick-upload`, `#quick-reset-filters`, `#quick-compare` y `#quick-download` y variantes de etiqueta para desktop/mobile.
- Conectados los botones en `js/main.js` mediante `setupQuickActionsListeners()` que reutiliza flujos existentes: dispara el input de archivo (`fileInput.click()` → `handleFileSelect`), llama a `uiControls.resetAllFilters()`, activa el toggle de comparación reusando `#toggle-comparison`, y llama a `handleDownload`.
- Sincronizado el estado visual del botón rápido de comparación (`quickCompareBtn`) con el estado de `imageComparison` y se resetea en `handleClearImage()` para mantener coherencia de UI.
- Añadidos estilos en `css/editor.css` para hacer la barra sticky, visualmente consistente y compacta en móvil (scroll horizontal, iconos + texto corto y botón primario para descarga).

### Testing
- Ejecutado `node --check js/main.js` y no se reportaron errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6a0984ac8331b2dcb88f04560eb4)