### PR TITLE
Añade navegación por tabs (desktop) y acordeón (mobile) en los controles del editor

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -178,6 +178,49 @@
   align-items: start;
 }
 
+.editor-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.editor-sections-nav {
+  position: sticky;
+  top: 0;
+  z-index: 8;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid #ececec;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(4px);
+}
+
+.editor-section-tab {
+  border: 1px solid #ddd;
+  background: #fff;
+  color: #555;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.editor-section-tab:hover {
+  border-color: #ff6600;
+  color: #ff6600;
+}
+
+.editor-section-tab.active {
+  border-color: #ff6600;
+  background: #ff6600;
+  color: #fff;
+}
+
 .controls-section {
   margin-bottom: 20px;
 }
@@ -200,6 +243,50 @@
   margin: 0;
   color: #666;
   font-size: 14px;
+}
+
+.section-panel {
+  margin: 0;
+  border: 1px solid #ececec;
+  border-radius: 12px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.section-panel-body {
+  padding: 16px;
+}
+
+.section-accordion-trigger {
+  width: 100%;
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 14px 16px;
+  border: 0;
+  border-bottom: 1px solid #ececec;
+  background: #fafafa;
+  color: #333;
+  font-size: 15px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.section-accordion-trigger.active {
+  color: #ff6600;
+}
+
+/* Desktop: comportamiento tab, solo una sección visible */
+@media (min-width: 769px) {
+  .section-panel {
+    display: none;
+  }
+
+  .section-panel.active {
+    display: block;
+  }
 }
 
 /* =============================================
@@ -298,8 +385,28 @@
     padding: 15px;
   }
 
-  .controls-section h3 {
-    font-size: 16px;
+  .editor-sections-nav {
+    display: none;
+  }
+
+  .section-accordion-trigger {
+    display: flex;
+  }
+
+  .section-panel {
+    border-radius: 10px;
+  }
+
+  .section-panel:not(.active) .section-panel-body {
+    display: none;
+  }
+
+  .section-panel.active .section-panel-body {
+    display: block;
+  }
+
+  .section-panel.active .section-accordion-trigger {
+    background: #fff4ec;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -67,11 +67,19 @@
 
       <!-- Panel de controles del editor (se mostrará cuando haya imagen) -->
       <div class="editor-controls" id="editorControls" style="display: none;">
-        <div class="editor-controls-grid">
+        <div class="editor-sections" id="editorSections">
+          <div class="editor-sections-nav" role="tablist" aria-label="Secciones del editor">
+            <button class="editor-section-tab active" type="button" role="tab" aria-selected="true" aria-controls="filters-panel" data-target="filters-panel">🎨 Filtros</button>
+            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="transforms-panel" data-target="transforms-panel">🔄 Transformar</button>
+            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="export-panel" data-target="export-panel">💾 Descargar</button>
+            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="comparison-panel" data-target="comparison-panel">⚖️ Comparar</button>
+            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="crop-panel" data-target="crop-panel">✂️ Recortar</button>
+          </div>
 
       <!-- Panel de Filtros -->
-      <div class="controls-section" id="filters-panel">
-        <h3>🎨 Filtros</h3>
+      <div class="controls-section section-panel active" id="filters-panel" data-section="filters-panel">
+        <button class="section-accordion-trigger" type="button" aria-expanded="true" aria-controls="filters-panel-body" data-target="filters-panel">🎨 Filtros</button>
+        <div class="section-panel-body" id="filters-panel-body">
 
         <!-- Brillo -->
         <div class="filter-control">
@@ -121,10 +129,12 @@
         <!-- Botón Resetear -->
         <button id="reset-filters">↺ Resetear Filtros</button>
       </div>
+      </div>
 
       <!-- Panel de Transformaciones -->
-      <div class="controls-section" id="transforms-panel">
-        <h3>🔄 Transformar</h3>
+      <div class="controls-section section-panel" id="transforms-panel" data-section="transforms-panel">
+        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="transforms-panel-body" data-target="transforms-panel">🔄 Transformar</button>
+        <div class="section-panel-body" id="transforms-panel-body">
 
         <div class="transform-buttons">
           <!-- Fila 1: Rotaciones -->
@@ -152,10 +162,12 @@
           </div>
         </div>
       </div>
+      </div>
 
       <!-- Panel de Exportación -->
-      <div class="controls-section" id="export-panel">
-        <h3>💾 Descargar</h3>
+      <div class="controls-section section-panel" id="export-panel" data-section="export-panel">
+        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="export-panel-body" data-target="export-panel">💾 Descargar</button>
+        <div class="section-panel-body" id="export-panel-body">
 
         <!-- Nombre del archivo -->
         <div class="form-group">
@@ -204,10 +216,12 @@
           <span class="download-text">Descargar Imagen</span>
         </button>
       </div>
+      </div>
 
       <!-- Panel de Comparación -->
-      <div class="controls-section" id="comparison-panel">
-        <h3>⚖️ Comparar</h3>
+      <div class="controls-section section-panel" id="comparison-panel" data-section="comparison-panel">
+        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="comparison-panel-body" data-target="comparison-panel">⚖️ Comparar</button>
+        <div class="section-panel-body" id="comparison-panel-body">
 
         <!-- Botón de toggle comparación -->
         <button id="toggle-comparison" class="btn-comparison">
@@ -234,10 +248,12 @@
           </div>
         </div>
       </div>
+      </div>
 
       <!-- Panel de Recorte -->
-      <div class="controls-section" id="crop-panel">
-        <h3>✂️ Recortar</h3>
+      <div class="controls-section section-panel" id="crop-panel" data-section="crop-panel">
+        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="crop-panel-body" data-target="crop-panel">✂️ Recortar</button>
+        <div class="section-panel-body" id="crop-panel-body">
 
         <!-- Selector de proporción -->
         <div class="crop-ratio-group">
@@ -279,6 +295,7 @@
           <p>• Mueve el área haciendo clic dentro</p>
           <p>• Redimensiona desde las esquinas</p>
         </div>
+      </div>
       </div>
 
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -26,6 +26,10 @@ let quickUploadBtn;
 let quickResetFiltersBtn;
 let quickCompareBtn;
 let quickDownloadBtn;
+let editorSectionTabs;
+let editorSectionPanels;
+let editorSectionAccordionTriggers;
+let activeEditorSectionId = 'filters-panel';
 
 /**
  * Inicialización cuando el DOM está listo
@@ -122,6 +126,9 @@ function getDOMReferences() {
   quickResetFiltersBtn = document.getElementById('quick-reset-filters');
   quickCompareBtn = document.getElementById('quick-compare');
   quickDownloadBtn = document.getElementById('quick-download');
+  editorSectionTabs = document.querySelectorAll('.editor-section-tab');
+  editorSectionPanels = document.querySelectorAll('.section-panel');
+  editorSectionAccordionTriggers = document.querySelectorAll('.section-accordion-trigger');
 }
 
 /**
@@ -148,6 +155,58 @@ function setupEventListeners() {
 
   // Listeners de acciones rápidas
   setupQuickActionsListeners();
+
+  // Listeners de navegación entre secciones (tabs/accordion)
+  setupEditorSectionNavigation();
+}
+
+/**
+ * Configura navegación de secciones con tabs (desktop) y acordeón (mobile)
+ */
+function setupEditorSectionNavigation() {
+  if (!editorSectionPanels?.length) return;
+
+  editorSectionTabs.forEach((tab) => {
+    tab.addEventListener('click', () => {
+      const targetId = tab.dataset.target;
+      setActiveEditorSection(targetId);
+    });
+  });
+
+  editorSectionAccordionTriggers.forEach((trigger) => {
+    trigger.addEventListener('click', () => {
+      const targetId = trigger.dataset.target;
+      setActiveEditorSection(targetId);
+    });
+  });
+
+  // Estado inicial: una sola sección abierta por defecto
+  setActiveEditorSection(activeEditorSectionId);
+}
+
+/**
+ * Activa una sección del editor y desactiva el resto
+ * @param {string|null} sectionId - ID de la sección a activar
+ */
+function setActiveEditorSection(sectionId) {
+  activeEditorSectionId = sectionId;
+
+  editorSectionPanels.forEach((panel) => {
+    const isActive = panel.id === sectionId;
+    panel.classList.toggle('active', isActive);
+  });
+
+  editorSectionTabs.forEach((tab) => {
+    const isActive = tab.dataset.target === sectionId;
+    tab.classList.toggle('active', isActive);
+    tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+  });
+
+  editorSectionAccordionTriggers.forEach((trigger) => {
+    const isActive = trigger.dataset.target === sectionId;
+    trigger.classList.toggle('active', isActive);
+    trigger.setAttribute('aria-expanded', isActive ? 'true' : 'false');
+  });
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Mejorar la UX del panel de controles mostrando una sola sección a la vez para evitar scroll largo.
- Permitir cambio rápido entre `#filters-panel`, `#transforms-panel`, `#export-panel`, `#comparison-panel` y `#crop-panel` tanto en desktop (tabs) como en mobile (acordeón).
- Mantener accesibilidad mínima con atributos ARIA en los triggers y tabs.

### Description
- Reestructura `index.html` para agrupar las secciones del editor dentro de un contenedor `editor-sections` que incluye una barra de tabs (`.editor-section-tab`) y triggers de acordeón (`.section-accordion-trigger`) por sección.
- Añade en `js/main.js` el estado `activeEditorSectionId`, referencias DOM para tabs/panels/triggers y las funciones `setupEditorSectionNavigation()` y `setActiveEditorSection()` para manejar la navegación y mantener una sola sección activa.
- Añade en `css/editor.css` estilos para la barra de navegación sticky (`.editor-sections-nav`), estilos de estado activo/inactivo para tabs y triggers, y reglas responsive que muestran tabs en desktop y comportamiento acordeón en mobile (colapsado/expandido).
- Comportamiento runtime: por defecto la sección `filters-panel` queda activa, los tabs cambian la sección en desktop y los triggers actúan como acordeón en mobile.

### Testing
- Ejecuté `node --check js/main.js` y el chequeo pasó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6b1c23f88331a3aebf0615784ff3)