### PR TITLE
Layout fluido: eliminar scroll anidado en `style.css` y `css/editor.css`

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -167,8 +167,8 @@
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   animation: fadeIn 0.4s ease;
-  overflow-y: auto;
-  max-height: calc(95vh - 100px);
+  overflow: visible;
+  max-height: none;
 }
 
 .editor-controls-grid {
@@ -294,7 +294,7 @@
   }
 
   .editor-controls {
-    margin: 15px auto;
+    margin: 15px auto 0;
     padding: 15px;
   }
 

--- a/style.css
+++ b/style.css
@@ -1,23 +1,21 @@
 body {
   font-family: 'Poppins', sans-serif;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100vh;
+  min-height: 100dvh;
   margin: 0;
+  padding: clamp(12px, 2.5vw, 24px);
+  box-sizing: border-box;
   background: linear-gradient(135deg, #ff9966, #ff5e62);
 }
 
 .card {
   background: #fff;
-  padding: 25px 30px;
+  padding: clamp(18px, 2.2vw, 30px);
   border-radius: 15px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   text-align: center;
   max-width: 1300px;
-  width: 98%;
-  max-height: 95vh;
-  overflow-y: auto;
+  width: min(1300px, 100%);
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
 }
@@ -25,9 +23,9 @@ body {
 .workspace {
   display: flex;
   flex-wrap: wrap;
-  gap: 30px;
+  gap: clamp(16px, 2vw, 30px);
   align-items: flex-start;
-  margin-top: 20px;
+  margin-top: clamp(14px, 1.8vw, 20px);
 }
 
 .canvas-panel {


### PR DESCRIPTION
### Motivation
- Eliminar patrones de altura fija (`100vh` / `95vh`) y scroll interno para permitir un único scroll natural en móviles y evitar scroll anidado en paneles.
- Mantener la experiencia en escritorio compacta con mínimo scroll visual mientras el documento fluye de forma responsiva.
- Usar spacing responsivo para que el layout se adapte sin depender de recortes de viewport.

### Description
- En `style.css` reemplacé `height: 100vh` por `min-height: 100dvh`, añadí `padding` responsivo y `box-sizing`, y ajusté `.card` para quitar `max-height` y `overflow-y: auto`, usando ancho centrado (`width: min(1300px, 100%)`) y `padding` con `clamp(...)`.
- Ajusté `.workspace` para usar `gap` y `margin-top` responsivos via `clamp(...)` para conservar densidad visual en desktop y mejorar flujo en pantallas pequeñas.
- En `css/editor.css` cambié `.editor-controls` de `overflow-y: auto` y `max-height: calc(95vh - 100px)` a `overflow: visible` y `max-height: none`, y ajusté el `margin` móvil a `margin: 15px auto 0` para evitar paneles con scroll propio.
- No se modificó JavaScript; solo ajustes de CSS orientados a layout y comportamiento de scroll.

### Testing
- Ejecuté `git diff -- style.css css/editor.css` para revisar las diferencias y confirmar los cambios aplicados, y la salida mostró las modificaciones esperadas.
- Ejecuté `rg "100vh|95vh|overflow-y:\s*auto|max-height:\s*calc\(95vh - 100px\)" style.css css/editor.css` y no devolvió coincidencias, confirmando que los patrones fueron removidos.
- Ejecuté `git commit -m "Refactoriza layout fluido y elimina scroll anidado"` y la confirmación del commit fue satisfactoria.
- Se creó el PR con la descripción y diffs correspondientes mediante la herramienta de PR; no se ejecutaron tests visuales automatizados porque no hay un entorno de navegador/screenshot automatizado en este flujo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6ba2a8d08331971dbedd738823df)