### PR TITLE
Reorganiza el editor con navegación lateral y layout de panel

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -180,9 +180,10 @@
 }
 
 .editor-sections {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
   gap: 14px;
+  align-items: start;
 }
 
 .editor-sections-nav {
@@ -190,25 +191,41 @@
   top: 0;
   z-index: 8;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 8px;
   padding: 8px;
-  border: 1px solid #ececec;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--bg-panel) 92%, #fff);
   backdrop-filter: blur(4px);
+  max-height: calc(95vh - 140px);
+  overflow-y: auto;
 }
 
 .editor-section-tab {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
   border: 1px solid #ddd;
   background: #fff;
   color: #555;
   border-radius: 8px;
-  padding: 8px 12px;
-  font-size: 13px;
+  padding: 10px 12px;
+  font-size: 14px;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.2s ease;
+  text-align: left;
+}
+
+.editor-tab-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.editor-tab-text {
+  flex: 1;
 }
 
 .editor-section-tab:hover {
@@ -252,6 +269,12 @@
   border-radius: 12px;
   background: #fff;
   overflow: hidden;
+  grid-column: 2;
+}
+
+.editor-sections-nav {
+  grid-column: 1;
+  grid-row: 1 / span 6;
 }
 
 .section-panel-body {
@@ -384,6 +407,11 @@
   .editor-controls {
     margin: 15px auto;
     padding: 15px;
+  }
+
+  .editor-sections {
+    display: flex;
+    flex-direction: column;
   }
 
   .editor-sections-nav {

--- a/index.html
+++ b/index.html
@@ -69,11 +69,26 @@
       <div class="editor-controls" id="editorControls" style="display: none;">
         <div class="editor-sections" id="editorSections">
           <div class="editor-sections-nav" role="tablist" aria-label="Secciones del editor">
-            <button class="editor-section-tab active" type="button" role="tab" aria-selected="true" aria-controls="filters-panel" data-target="filters-panel">🎨 Filtros</button>
-            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="transforms-panel" data-target="transforms-panel">🔄 Transformar</button>
-            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="export-panel" data-target="export-panel">💾 Descargar</button>
-            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="comparison-panel" data-target="comparison-panel">⚖️ Comparar</button>
-            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="crop-panel" data-target="crop-panel">✂️ Recortar</button>
+            <button class="editor-section-tab active" type="button" role="tab" aria-selected="true" aria-controls="filters-panel" data-target="filters-panel">
+              <span class="editor-tab-icon">🎨</span>
+              <span class="editor-tab-text">Filtros</span>
+            </button>
+            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="transforms-panel" data-target="transforms-panel">
+              <span class="editor-tab-icon">🔄</span>
+              <span class="editor-tab-text">Transformar</span>
+            </button>
+            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="export-panel" data-target="export-panel">
+              <span class="editor-tab-icon">💾</span>
+              <span class="editor-tab-text">Descargar</span>
+            </button>
+            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="comparison-panel" data-target="comparison-panel">
+              <span class="editor-tab-icon">⚖️</span>
+              <span class="editor-tab-text">Comparar</span>
+            </button>
+            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="crop-panel" data-target="crop-panel">
+              <span class="editor-tab-icon">✂️</span>
+              <span class="editor-tab-text">Recortar</span>
+            </button>
           </div>
 
       <!-- Panel de Filtros -->


### PR DESCRIPTION
### Motivation
- Mejorar la organización del panel del editor para ofrecer una navegación lateral en escritorio más clara y alineada con la referencia visual proporcionada. 
- Mantener el comportamiento actual de acordeón en móvil para no romper la experiencia responsive.

### Description
- Actualicé `index.html` para separar icono y texto en los botones de sección añadiendo `editor-tab-icon` y `editor-tab-text` dentro de cada `.editor-section-tab`.
- Reescribí el layout de la zona de controles en `css/editor.css` para usar un `grid` de dos columnas (`220px` para la navegación + contenido activo) y convertir `.editor-sections-nav` a un panel vertical con scroll interno.
- Ajusté estilos de `.editor-section-tab`, `.editor-tab-icon`, `.editor-tab-text` y `.section-panel` para soportar el nuevo layout y estados visuales (hover/active), preservando el acordeón y el flujo existente en pantallas pequeñas.
- Archivos modificados: `index.html`, `css/editor.css`.

### Testing
- Se ejecutaron las comprobaciones de consistencia del repositorio y no arrojaron errores (repository checks passed).
- Verificado visualmente que el layout conserva el comportamiento de acordeón en mobile y despliega la navegación lateral con contenido en escritorio (manual preview).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6f04f82c833180102088da6a49cb)