### PR TITLE
Refina layout del editor: canvas principal, panel de herramientas colapsable y acciones rápidas más sutiles

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -16,32 +16,31 @@
   position: sticky;
   top: 0;
   z-index: 20;
-  flex: 1 1 100%;
+  width: 100%;
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 6px;
   align-items: center;
-  justify-content: center;
-  padding: 10px;
-  margin-bottom: 8px;
-  background: var(--surface-overlay);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  backdrop-filter: blur(4px);
+  justify-content: flex-start;
+  padding: 6px;
+  margin-bottom: 2px;
+  background: color-mix(in srgb, var(--surface-2) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
+  border-radius: 10px;
 }
 
 .quick-action-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 8px 12px;
+  gap: 6px;
+  padding: 6px 10px;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
   background: var(--bg-panel);
   color: var(--color-text);
   font-weight: 600;
-  font-size: 14px;
+  font-size: 13px;
   cursor: pointer;
   transition: all 0.2s ease;
 }
@@ -49,7 +48,6 @@
 .quick-action-btn:hover {
   border-color: var(--color-primary);
   color: var(--color-primary);
-  transform: translateY(-1px);
 }
 
 .quick-action-btn.active {
@@ -59,9 +57,25 @@
 }
 
 .quick-action-btn-primary {
+  margin-right: 4px;
   background: var(--color-primary);
   border-color: var(--color-primary);
   color: var(--text-inverse);
+  box-shadow: 0 1px 4px color-mix(in srgb, var(--color-primary) 35%, transparent);
+}
+
+.quick-action-btn-secondary {
+  opacity: 0.72;
+  font-weight: 500;
+}
+
+.quick-action-btn-secondary .quick-action-label-desktop {
+  opacity: 0.86;
+}
+
+.quick-action-btn-secondary:hover,
+.quick-action-btn-secondary:focus-visible {
+  opacity: 1;
 }
 
 .quick-action-btn-primary:hover {
@@ -168,16 +182,16 @@
    ============================================= */
 
 .editor-controls {
-  flex: 1 1 500px;
   width: 100%;
-  padding: 20px;
+  max-width: 440px;
+  padding: 16px;
   background: var(--bg-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
   animation: fadeIn 0.4s ease;
   overflow-y: auto;
-  max-height: calc(95vh - 100px);
+  max-height: calc(95vh - 170px);
 }
 
 .editor-controls-grid {
@@ -189,8 +203,8 @@
 
 .editor-sections {
   display: grid;
-  grid-template-columns: 220px minmax(0, 1fr);
-  gap: 14px;
+  grid-template-columns: 132px minmax(0, 1fr);
+  gap: 10px;
   align-items: start;
 }
 
@@ -383,8 +397,9 @@
     justify-content: flex-start;
     overflow-x: auto;
     flex-wrap: nowrap;
-    padding: 8px;
-    gap: 8px;
+    padding: 6px;
+    gap: 6px;
+    margin-bottom: 6px;
   }
 
   .quick-action-btn {
@@ -415,13 +430,16 @@
   }
 
   .editor-controls {
-    margin: 15px auto;
-    padding: 15px;
+    margin: 4px auto;
+    max-width: 100%;
+    padding: 12px;
+    max-height: none;
   }
 
   .editor-sections {
     display: flex;
     flex-direction: column;
+    gap: 10px;
   }
 
   .editor-sections-nav {
@@ -434,6 +452,7 @@
 
   .section-panel {
     border-radius: 10px;
+    border: 1px solid var(--border-soft);
   }
 
   .section-panel:not(.active) .section-panel-body {
@@ -451,15 +470,15 @@
 
 @media (max-width: 480px) {
   .quick-actions-bar {
-    top: 6px;
-    padding: 6px;
+    top: 4px;
+    padding: 5px;
     border-radius: 10px;
   }
 
   .quick-action-btn {
-    min-width: 84px;
-    padding: 7px 8px;
-    gap: 6px;
+    min-width: 70px;
+    padding: 6px 8px;
+    gap: 5px;
     border-radius: 8px;
     font-size: 12px;
   }
@@ -482,6 +501,33 @@
   .main-canvas,
 #mainCanvas {
     max-height: 400px;
+  }
+}
+
+
+@media (min-width: 769px) {
+  .workspace-tools {
+    position: sticky;
+    top: 18px;
+    align-self: start;
+  }
+
+  .workspace-tools:not([open]) .editor-controls {
+    display: none !important;
+  }
+}
+
+@media (max-width: 768px) {
+  .workspace-tools {
+    width: 100%;
+  }
+
+  .workspace-tools:not([open]) .editor-controls {
+    display: none !important;
+  }
+
+  .workspace-tools-toggle {
+    padding: 10px 8px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -32,30 +32,30 @@
     <div id="status-text"></div>
 
     <div class="workspace">
-      <div class="quick-actions-bar" id="quickActionsBar" aria-label="Acciones rápidas del editor">
-        <button id="quick-upload" class="quick-action-btn" type="button" title="Subir o reemplazar imagen">
-          <span class="quick-action-icon">🖼️</span>
-          <span class="quick-action-label quick-action-label-desktop">Subir/Reemplazar imagen</span>
-          <span class="quick-action-label quick-action-label-mobile">Subir</span>
-        </button>
-        <button id="quick-reset-filters" class="quick-action-btn" type="button" title="Resetear todos los filtros">
-          <span class="quick-action-icon">↺</span>
-          <span class="quick-action-label quick-action-label-desktop">Reset filtros</span>
-          <span class="quick-action-label quick-action-label-mobile">Reset</span>
-        </button>
-        <button id="quick-compare" class="quick-action-btn" type="button" title="Comparar imagen original y editada">
-          <span class="quick-action-icon">👁️</span>
-          <span class="quick-action-label quick-action-label-desktop">Comparar original</span>
-          <span class="quick-action-label quick-action-label-mobile">Comparar</span>
-        </button>
-        <button id="quick-download" class="quick-action-btn quick-action-btn-primary" type="button" title="Descargar imagen editada">
-          <span class="quick-action-icon">⬇️</span>
-          <span class="quick-action-label quick-action-label-desktop">Descargar</span>
-          <span class="quick-action-label quick-action-label-mobile">Guardar</span>
-        </button>
-      </div>
+      <div class="canvas-panel workspace-canvas-stage">
+        <div class="quick-actions-bar" id="quickActionsBar" aria-label="Acciones rápidas del editor">
+          <button id="quick-download" class="quick-action-btn quick-action-btn-primary" type="button" title="Exportar imagen editada">
+            <span class="quick-action-icon">⬇️</span>
+            <span class="quick-action-label quick-action-label-desktop">Exportar</span>
+            <span class="quick-action-label quick-action-label-mobile">Exportar</span>
+          </button>
+          <button id="quick-upload" class="quick-action-btn quick-action-btn-secondary" type="button" title="Subir o reemplazar imagen">
+            <span class="quick-action-icon">🖼️</span>
+            <span class="quick-action-label quick-action-label-desktop">Subir</span>
+            <span class="quick-action-label quick-action-label-mobile">Subir</span>
+          </button>
+          <button id="quick-reset-filters" class="quick-action-btn quick-action-btn-secondary" type="button" title="Resetear todos los filtros">
+            <span class="quick-action-icon">↺</span>
+            <span class="quick-action-label quick-action-label-desktop">Reset</span>
+            <span class="quick-action-label quick-action-label-mobile">Reset</span>
+          </button>
+          <button id="quick-compare" class="quick-action-btn quick-action-btn-secondary" type="button" title="Comparar imagen original y editada">
+            <span class="quick-action-icon">👁️</span>
+            <span class="quick-action-label quick-action-label-desktop">Comparar</span>
+            <span class="quick-action-label quick-action-label-mobile">Comparar</span>
+          </button>
+        </div>
 
-      <div class="canvas-panel">
         <!-- Canvas Container con placeholder -->
         <div id="canvas-container" class="canvas-container">
           <canvas id="mainCanvas" class="main-canvas"></canvas>
@@ -64,6 +64,9 @@
 
         <button id="clearBtn" class="btn btn-danger">Borrar imagen</button>
       </div>
+
+      <details class="workspace-tools" open>
+        <summary class="workspace-tools-toggle">🧰 Herramientas</summary>
 
       <!-- Panel de controles del editor (se mostrará cuando haya imagen) -->
       <div class="editor-controls" id="editorControls" style="display: none;">
@@ -315,6 +318,7 @@
 
         </div>
       </div>
+      </details>
     </div>
   </div>
   <!-- Scripts del editor (módulos cargados en orden) -->

--- a/style.css
+++ b/style.css
@@ -75,31 +75,61 @@ h1 {
 
 .card {
   background: var(--surface-2);
-  padding: 25px 30px;
+  padding: clamp(20px, 2.4vw, 32px);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
   text-align: center;
-  max-width: 1300px;
-  width: 98%;
+  max-width: 1460px;
+  width: min(97vw, 1460px);
   max-height: 95vh;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  gap: 10px;
 }
 
 .workspace {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 30px;
-  align-items: flex-start;
-  margin-top: 20px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.75fr) minmax(300px, 0.9fr);
+  gap: clamp(16px, 2vw, 28px);
+  align-items: start;
+  margin-top: 16px;
 }
 
 .canvas-panel {
-  flex: 1 1 500px;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+.workspace-canvas-stage {
+  gap: 12px;
+}
+
+.workspace-tools {
+  min-width: 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  box-shadow: var(--shadow-sm);
+  padding: 10px;
+}
+
+.workspace-tools-toggle {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--text-primary);
+  padding: 6px 8px 10px;
+  text-align: left;
+}
+
+.workspace-tools-toggle::-webkit-details-marker {
+  display: none;
 }
 
 /* Base components */
@@ -273,4 +303,21 @@ input[type="file"] {
 .status-success {
   color: var(--success);
   font-weight: 600;
+}
+
+
+@media (max-width: 900px) {
+  .workspace {
+    grid-template-columns: 1fr;
+    gap: 14px;
+  }
+
+  .workspace-tools {
+    order: 2;
+    padding: 8px;
+  }
+
+  .workspace-canvas-stage {
+    order: 1;
+  }
 }


### PR DESCRIPTION
### Motivation
- Priorizar la zona de edición visual haciendo que el canvas sea el elemento dominante y reducir la prominencia de controles secundarios en la UI. 
- Aligerar la barra de acciones rápidas para disminuir el peso visual y enfatizar una única acción primaria (`Exportar`).
- Mejorar el espaciado y límites de los contenedores (`.card`, `.editor-controls`, `.card`) para más respiración visual. 
- Asegurar comportamiento responsive donde en mobile el canvas se muestre primero y los controles queden en bloques colapsables.

### Description
- Reorganicé la estructura de `index.html` moviendo la barra rápida dentro del stage del canvas y envolviendo los controles del editor en `<details class="workspace-tools">` con `summary.workspace-tools-toggle` para un panel lateral colapsable; añadí clases `workspace-canvas-stage` y `workspace-tools` para el layout. 
- Actualicé `css/editor.css` para reducir padding/gap, suavizar borde y eliminar el blur pesado de `.quick-actions-bar`, compactar estilos de `.quick-action-btn`, añadir `.quick-action-btn-secondary` para rebajar la prominencia de acciones secundarias y mantener `quick-download` como acción primaria más visible. 
- Ajusté `style.css` para cambiar `.card` (padding y max-width), convertir `.workspace` a grid con columnas `canvas : herramientas`, y añadir estilos auxiliares (`.workspace-tools`, `.workspace-canvas-stage`, `.workspace-tools-toggle`) y reglas responsive. 
- Añadí media queries y reglas para mobile que colocan la columna del canvas primero y transforman los paneles de herramientas en acordeones/desplegables para priorizar el contenido visual.

### Testing
- Ejecuté `git diff --check` y no reportó warnings o conflictos, por lo que los cambios de formato son coherentes con el árbol de trabajo. (OK)
- Verifiqué la sintaxis de los scripts con `node --check js/main.js` y `node --check js/ui-controls.js`, ambos pasaron sin errores de parsing. (OK)
- No se cambiaron las funciones lógicas de edición/exportación; los cambios son estructurales y de estilos únicamente, por lo que las pruebas de integración visual deberían realizarse en un navegador para validar comportamiento runtime. (N/A automated)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5e57b6108331a238a51f86715f03)