### PR TITLE
Replace editor control emojis with consistent SVG iconography

### DIFF
--- a/css/crop.css
+++ b/css/crop.css
@@ -68,7 +68,7 @@
 #canvas-container.crop-active { cursor: crosshair; }
 
 #canvas-container.crop-active::before {
-  content: '✂️ RECORTANDO - Arrastra para seleccionar área';
+  content: 'RECORTANDO - Arrastra para seleccionar área';
   position: absolute;
   top: 15px;
   left: 50%;

--- a/index.html
+++ b/index.html
@@ -35,22 +35,22 @@
       <div class="canvas-panel workspace-canvas-stage">
         <div class="quick-actions-bar" id="quickActionsBar" aria-label="Acciones rápidas del editor">
           <button id="quick-download" class="quick-action-btn quick-action-btn-primary" type="button" title="Exportar imagen editada">
-            <span class="quick-action-icon">⬇️</span>
+            <span class="quick-action-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 4v11"></path><path d="m7 11 5 5 5-5"></path><path d="M5 20h14"></path></svg></span>
             <span class="quick-action-label quick-action-label-desktop">Exportar</span>
             <span class="quick-action-label quick-action-label-mobile">Exportar</span>
           </button>
           <button id="quick-upload" class="quick-action-btn quick-action-btn-secondary" type="button" title="Subir o reemplazar imagen">
-            <span class="quick-action-icon">🖼️</span>
+            <span class="quick-action-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="2"></rect><path d="m8 13 3-3 5 5"></path><circle cx="16" cy="9" r="1.5"></circle></svg></span>
             <span class="quick-action-label quick-action-label-desktop">Subir</span>
             <span class="quick-action-label quick-action-label-mobile">Subir</span>
           </button>
           <button id="quick-reset-filters" class="quick-action-btn quick-action-btn-secondary" type="button" title="Resetear todos los filtros">
-            <span class="quick-action-icon">↺</span>
+            <span class="quick-action-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M3 12a9 9 0 1 0 3-6.7"></path><path d="M3 4v5h5"></path></svg></span>
             <span class="quick-action-label quick-action-label-desktop">Reset</span>
             <span class="quick-action-label quick-action-label-mobile">Reset</span>
           </button>
           <button id="quick-compare" class="quick-action-btn quick-action-btn-secondary" type="button" title="Comparar imagen original y editada">
-            <span class="quick-action-icon">👁️</span>
+            <span class="quick-action-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6Z"></path><circle cx="12" cy="12" r="3"></circle></svg></span>
             <span class="quick-action-label quick-action-label-desktop">Comparar</span>
             <span class="quick-action-label quick-action-label-mobile">Comparar</span>
           </button>
@@ -66,43 +66,43 @@
       </div>
 
       <details class="workspace-tools" open>
-        <summary class="workspace-tools-toggle">🧰 Herramientas</summary>
+        <summary class="workspace-tools-toggle"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><rect x="3" y="7" width="18" height="12" rx="2"></rect><path d="M9 7V5h6v2"></path><path d="M3 12h18"></path></svg></span> Herramientas</summary>
 
       <!-- Panel de controles del editor (se mostrará cuando haya imagen) -->
       <div class="editor-controls" id="editorControls" style="display: none;">
         <div class="editor-sections" id="editorSections">
           <div class="editor-sections-nav" role="tablist" aria-label="Secciones del editor">
             <button class="editor-section-tab active" type="button" role="tab" aria-selected="true" aria-controls="filters-panel" data-target="filters-panel">
-              <span class="editor-tab-icon">🎨</span>
+              <span class="editor-tab-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="8" cy="9" r="2"></circle><circle cx="14" cy="7" r="2"></circle><circle cx="17" cy="12" r="2"></circle><path d="M12 20a8 8 0 1 1 0-16h1a3 3 0 0 1 0 6h-1a3 3 0 1 0 0 6Z"></path></svg></span>
               <span class="editor-tab-text">Filtros</span>
             </button>
             <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="transforms-panel" data-target="transforms-panel">
-              <span class="editor-tab-icon">🔄</span>
-              <span class="editor-tab-text">Transformar</span>
+              <span class="editor-tab-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M21 4v6h-6"></path><path d="M3 20v-6h6"></path><path d="M20 10a8 8 0 0 0-14-3"></path><path d="M4 14a8 8 0 0 0 14 3"></path></svg></span>
+              <span class="editor-tab-text">Ajustar</span>
             </button>
             <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="export-panel" data-target="export-panel">
-              <span class="editor-tab-icon">💾</span>
-              <span class="editor-tab-text">Descargar</span>
+              <span class="editor-tab-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3v11"></path><path d="m7 10 5 5 5-5"></path><path d="M4 19h16"></path></svg></span>
+              <span class="editor-tab-text">Exportar</span>
             </button>
             <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="comparison-panel" data-target="comparison-panel">
-              <span class="editor-tab-icon">⚖️</span>
+              <span class="editor-tab-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 4v16"></path><path d="M5 8h14"></path><path d="m8 8-3 5h6l-3-5Z"></path><path d="m16 8-3 5h6l-3-5Z"></path></svg></span>
               <span class="editor-tab-text">Comparar</span>
             </button>
             <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="crop-panel" data-target="crop-panel">
-              <span class="editor-tab-icon">✂️</span>
+              <span class="editor-tab-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2"></circle><circle cx="6" cy="18" r="2"></circle><path d="M20 4 8 16"></path><path d="m8 8 12 12"></path></svg></span>
               <span class="editor-tab-text">Recortar</span>
             </button>
           </div>
 
       <!-- Panel de Filtros -->
       <div id="filters-panel" class="controls-section section-panel panel panel-filters active" data-section="filters-panel">
-        <button class="section-accordion-trigger" type="button" aria-expanded="true" aria-controls="filters-panel-body" data-target="filters-panel">🎨 Filtros</button>
+        <button class="section-accordion-trigger" type="button" aria-expanded="true" aria-controls="filters-panel-body" data-target="filters-panel"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="8" cy="9" r="2"></circle><circle cx="14" cy="7" r="2"></circle><circle cx="17" cy="12" r="2"></circle><path d="M12 20a8 8 0 1 1 0-16h1a3 3 0 0 1 0 6h-1a3 3 0 1 0 0 6Z"></path></svg></span> Filtros</button>
         <div class="section-panel-body" id="filters-panel-body">
 
         <!-- Brillo -->
         <div class="filter-control">
           <div class="filter-label">
-            <span class="filter-name">☀️ Brillo</span>
+            <span class="filter-name">Brillo</span>
             <span class="filter-value" id="brightness-value">100</span>
           </div>
           <input type="range" id="brightness" class="range" min="0" max="200" value="100" step="1">
@@ -111,7 +111,7 @@
         <!-- Contraste -->
         <div class="filter-control">
           <div class="filter-label">
-            <span class="filter-name">🌗 Contraste</span>
+            <span class="filter-name">Contraste</span>
             <span class="filter-value" id="contrast-value">100</span>
           </div>
           <input type="range" id="contrast" class="range" min="0" max="200" value="100" step="1">
@@ -120,7 +120,7 @@
         <!-- Saturación -->
         <div class="filter-control">
           <div class="filter-label">
-            <span class="filter-name">🎨 Saturación</span>
+            <span class="filter-name">Saturación</span>
             <span class="filter-value" id="saturation-value">100</span>
           </div>
           <input type="range" id="saturation" class="range" min="0" max="200" value="100" step="1">
@@ -129,7 +129,7 @@
         <!-- Desenfoque -->
         <div class="filter-control">
           <div class="filter-label">
-            <span class="filter-name">🌫️ Desenfoque</span>
+            <span class="filter-name">Desenfoque</span>
             <span class="filter-value" id="blur-value">0px</span>
           </div>
           <input type="range" id="blur" class="range" min="0" max="10" value="0" step="0.5">
@@ -138,44 +138,44 @@
         <!-- Escala de Grises -->
         <div class="filter-control">
           <div class="filter-label">
-            <span class="filter-name">⚫ Blanco y Negro</span>
+            <span class="filter-name">Blanco y negro</span>
             <span class="filter-value" id="grayscale-value">0%</span>
           </div>
           <input type="range" id="grayscale" class="range" min="0" max="100" value="0" step="1">
         </div>
 
         <!-- Botón Resetear -->
-        <button id="reset-filters" class="btn btn-secondary btn-reset-filters">↺ Resetear Filtros</button>
+        <button id="reset-filters" class="btn btn-secondary btn-reset-filters"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M3 12a9 9 0 1 0 3-6.7"></path><path d="M3 4v5h5"></path></svg></span> Reiniciar filtros</button>
       </div>
       </div>
 
       <!-- Panel de Transformaciones -->
       <div id="transforms-panel" class="controls-section section-panel panel panel-transforms" data-section="transforms-panel">
-        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="transforms-panel-body" data-target="transforms-panel">🔄 Transformar</button>
+        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="transforms-panel-body" data-target="transforms-panel"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M21 4v6h-6"></path><path d="M3 20v-6h6"></path><path d="M20 10a8 8 0 0 0-14-3"></path><path d="M4 14a8 8 0 0 0 14 3"></path></svg></span> Ajustar</button>
         <div class="section-panel-body" id="transforms-panel-body">
 
         <div class="transform-buttons">
           <!-- Fila 1: Rotaciones -->
           <div class="button-row">
             <button id="rotate-left" class="btn-transform btn btn-secondary" title="Rotar 90° izquierda">
-              <span class="btn-icon">↶</span>
-              <span class="btn-label">Rotar ←</span>
+              <span class="btn-icon icon icon-md" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M3 6v6h6"></path><path d="M20 18a8 8 0 1 0-8-14"></path></svg></span>
+              <span class="btn-label">Rotar izq.</span>
             </button>
             <button id="rotate-right" class="btn-transform btn btn-secondary" title="Rotar 90° derecha">
-              <span class="btn-icon">↷</span>
-              <span class="btn-label">Rotar →</span>
+              <span class="btn-icon icon icon-md" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M21 6v6h-6"></path><path d="M4 18a8 8 0 1 1 8-14"></path></svg></span>
+              <span class="btn-label">Rotar der.</span>
             </button>
           </div>
 
           <!-- Fila 2: Volteos -->
           <div class="button-row">
             <button id="flip-horizontal" class="btn-transform btn btn-secondary" title="Voltear horizontal">
-              <span class="btn-icon">↔️</span>
-              <span class="btn-label">Voltear ↔</span>
+              <span class="btn-icon icon icon-md" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="m7 12 3-3"></path><path d="m7 12 3 3"></path><path d="M17 12H8"></path><path d="m17 12-3-3"></path><path d="m17 12-3 3"></path></svg></span>
+              <span class="btn-label">Voltear horiz.</span>
             </button>
             <button id="flip-vertical" class="btn-transform btn btn-secondary" title="Voltear vertical">
-              <span class="btn-icon">↕️</span>
-              <span class="btn-label">Voltear ↕</span>
+              <span class="btn-icon icon icon-md" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="m12 7 3 3"></path><path d="m12 7-3 3"></path><path d="M12 17V8"></path><path d="m12 17 3-3"></path><path d="m12 17-3-3"></path></svg></span>
+              <span class="btn-label">Voltear vert.</span>
             </button>
           </div>
         </div>
@@ -184,7 +184,7 @@
 
       <!-- Panel de Exportación -->
       <div id="export-panel" class="controls-section section-panel panel panel-export" data-section="export-panel">
-        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="export-panel-body" data-target="export-panel">💾 Descargar</button>
+        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="export-panel-body" data-target="export-panel"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3v11"></path><path d="m7 10 5 5 5-5"></path><path d="M4 19h16"></path></svg></span> Exportar</button>
         <div class="section-panel-body" id="export-panel-body">
 
         <!-- Nombre del archivo -->
@@ -230,21 +230,21 @@
 
         <!-- Botón de descarga -->
         <button id="download-btn" class="btn-download btn btn-primary">
-          <span class="download-icon">⬇️</span>
-          <span class="download-text">Descargar Imagen</span>
+          <span class="download-icon icon icon-md" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 4v11"></path><path d="m7 11 5 5 5-5"></path><path d="M5 20h14"></path></svg></span>
+          <span class="download-text">Exportar imagen</span>
         </button>
       </div>
       </div>
 
       <!-- Panel de Comparación -->
       <div id="comparison-panel" class="controls-section section-panel panel panel-comparison" data-section="comparison-panel">
-        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="comparison-panel-body" data-target="comparison-panel">⚖️ Comparar</button>
+        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="comparison-panel-body" data-target="comparison-panel"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 4v16"></path><path d="M5 8h14"></path><path d="m8 8-3 5h6l-3-5Z"></path><path d="m16 8-3 5h6l-3-5Z"></path></svg></span> Comparar</button>
         <div class="section-panel-body" id="comparison-panel-body">
 
         <!-- Botón de toggle comparación -->
         <button id="toggle-comparison" class="btn-comparison btn btn-secondary btn-toggle-comparison">
-          <span class="btn-icon">👁️</span>
-          <span class="btn-text">Ver Original</span>
+          <span class="btn-icon icon icon-md" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6Z"></path><circle cx="12" cy="12" r="3"></circle></svg></span>
+          <span class="btn-text">Comparar</span>
         </button>
 
         <!-- Control de vista dividida -->
@@ -270,7 +270,7 @@
 
       <!-- Panel de Recorte -->
       <div id="crop-panel" class="controls-section section-panel panel panel-crop" data-section="crop-panel">
-        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="crop-panel-body" data-target="crop-panel">✂️ Recortar</button>
+        <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="crop-panel-body" data-target="crop-panel"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2"></circle><circle cx="6" cy="18" r="2"></circle><path d="M20 4 8 16"></path><path d="m8 8 12 12"></path></svg></span> Recortar</button>
         <div class="section-panel-body" id="crop-panel-body">
 
         <!-- Selector de proporción -->
@@ -289,18 +289,18 @@
         <!-- Botones de recorte -->
         <div class="crop-buttons">
           <button id="start-crop" class="btn btn-secondary btn-start-crop">
-            <span class="btn-icon">✂️</span>
-            <span>Iniciar Recorte</span>
+            <span class="btn-icon icon icon-md" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2"></circle><circle cx="6" cy="18" r="2"></circle><path d="M20 4 8 16"></path><path d="m8 8 12 12"></path></svg></span>
+            <span>Recortar</span>
           </button>
 
           <!-- Botones de acción (visibles durante recorte) -->
           <div class="crop-action-buttons" id="crop-actions">
             <button id="apply-crop" class="btn btn-primary btn-apply-crop">
-              <span>✓</span>
+              <span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="m5 12 4 4 10-10"></path></svg></span>
               <span>Aplicar</span>
             </button>
             <button id="cancel-crop" class="btn btn-secondary btn-cancel-crop">
-              <span>✗</span>
+              <span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="m6 6 12 12"></path><path d="m18 6-12 12"></path></svg></span>
               <span>Cancelar</span>
             </button>
           </div>

--- a/style.css
+++ b/style.css
@@ -73,6 +73,36 @@ h1 {
   margin-bottom: 15px;
 }
 
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  color: currentColor;
+  flex-shrink: 0;
+}
+
+.icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.icon-sm {
+  width: 16px;
+  height: 16px;
+}
+
+.icon-md {
+  width: 20px;
+  height: 20px;
+}
+
 .card {
   background: var(--surface-2);
   padding: clamp(20px, 2.4vw, 32px);


### PR DESCRIPTION
### Motivation
- Sustituir emojis usados como iconos en controles críticos por SVGs con trazo uniforme para mejorar consistencia visual y accesibilidad.
- Añadir utilidades CSS para tamaño y alineación homogénea de iconos, y mantener solo emojis en copy de onboarding para mantener cercanía sin afectar la usabilidad.
- Simplificar y clarificar labels de acciones usando verbos cortos y directos (`Recortar`, `Comparar`, `Exportar`).

### Description
- Reemplacé emojis en pestañas, botones de la barra rápida, triggers de acordeón y botones de recorte/compare/export en `index.html` por SVGs inline con la clase `icon` y variantes `icon-sm`/`icon-md` para tamaño uniforme.
- Añadí las utilidades globales `.icon`, `.icon-sm` y `.icon-md` en `style.css` que aplican `stroke: currentColor`, `stroke-width`, `stroke-linecap` y `stroke-linejoin` para un trazo coherente entre iconos.
- Ajusté textos de control y acciones clave en `index.html` para usar verbos claros y cortos (por ejemplo `Exportar`, `Comparar`, `Recortar`, `Reiniciar filtros`, `Exportar imagen`).
- Eliminé el emoji del estado de recorte en `css/crop.css` para que los mensajes operativos no dependan de emojis.

### Testing
- Ejecuté la búsqueda con `rg -n "📸|⬇️|🖼️|↺|👁️|🧰|🎨|🔄|💾|⚖️|✂️|✓|✗|☀️|🌗|🌫️|⚫" index.html css/*.css style.css` para confirmar que solo quedan emojis en el copy de onboarding y la comprobación fue exitosa.
- Verifiqué el estado del repositorio con `git status --short` y confirmé los cambios listados como modificados exitosamente.
- Realicé commit de los cambios (`Replace control emojis with consistent SVG icon system`) y la operación completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6280f1948331a3d32f6765069087)