### PR TITLE
Refina escala tipográfica, spacing y densidad de UI; suaviza botones de transformaciones

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -19,28 +19,29 @@
   width: 100%;
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-1);
   align-items: center;
   justify-content: flex-start;
-  padding: 6px;
-  margin-bottom: 2px;
+  padding: var(--space-1);
+  margin-bottom: var(--space-1);
   background: color-mix(in srgb, var(--surface-2) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
 }
 
 .quick-action-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 6px 10px;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-sm);
   border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
   background: var(--bg-panel);
   color: var(--color-text);
   font-weight: 600;
-  font-size: 13px;
+  font-size: var(--text-xs);
+  line-height: var(--leading-tight);
   cursor: pointer;
   transition: all 0.2s ease;
 }
@@ -57,7 +58,7 @@
 }
 
 .quick-action-btn-primary {
-  margin-right: 4px;
+  margin-right: var(--space-1);
   background: var(--color-primary);
   border-color: var(--color-primary);
   color: var(--text-inverse);
@@ -85,7 +86,7 @@
 }
 
 .quick-action-icon {
-  font-size: 16px;
+  font-size: 15px;
   line-height: 1;
 }
 
@@ -103,7 +104,7 @@
   width: 100%;
   max-width: 800px;
   min-height: 300px;
-  margin: 0 auto 20px auto;
+  margin: 0 auto var(--space-4) auto;
   background: var(--bg-surface);
   border: 2px dashed var(--color-border-strong);
   border-radius: var(--radius-md);
@@ -184,27 +185,27 @@
 .editor-controls {
   width: 100%;
   max-width: 440px;
-  padding: 16px;
+  padding: var(--space-3);
   background: var(--bg-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
   animation: fadeIn 0.4s ease;
   overflow-y: auto;
-  max-height: calc(95vh - 170px);
+  max-height: calc(95vh - 150px);
 }
 
 .editor-controls-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 20px;
+  gap: var(--space-4);
   align-items: start;
 }
 
 .editor-sections {
   display: grid;
   grid-template-columns: 132px minmax(0, 1fr);
-  gap: 10px;
+  gap: var(--space-2);
   align-items: start;
 }
 
@@ -214,35 +215,36 @@
   z-index: 8;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 8px;
+  gap: var(--space-1);
+  padding: var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--surface-overlay);
   backdrop-filter: blur(4px);
-  max-height: calc(95vh - 140px);
+  max-height: calc(95vh - 120px);
   overflow-y: auto;
 }
 
 .editor-section-tab {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-2);
   width: 100%;
   border: 1px solid var(--border-default);
   background: var(--surface-2);
   color: var(--text-secondary);
-  border-radius: 8px;
-  padding: 10px 12px;
-  font-size: 14px;
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
   font-weight: 600;
+  line-height: var(--leading-tight);
   cursor: pointer;
   transition: all 0.2s ease;
   text-align: left;
 }
 
 .editor-tab-icon {
-  font-size: 16px;
+  font-size: 15px;
   line-height: 1;
 }
 
@@ -262,7 +264,7 @@
 }
 
 .controls-section {
-  margin-bottom: 20px;
+  margin-bottom: var(--space-4);
 }
 
 .controls-section:last-child {
@@ -270,13 +272,14 @@
 }
 
 .controls-section h3 {
-  margin: 0 0 15px 0;
+  margin: 0 0 var(--space-2) 0;
   font-size: var(--section-title-size);
   font-weight: 600;
   color: var(--color-text);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
+  line-height: var(--leading-tight);
 }
 
 .controls-section p {
@@ -300,7 +303,7 @@
 }
 
 .section-panel-body {
-  padding: 16px;
+  padding: var(--space-3);
 }
 
 .section-accordion-trigger {
@@ -308,14 +311,15 @@
   display: none;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  padding: 14px 16px;
+  gap: var(--space-2);
+  padding: var(--space-3);
   border: 0;
   border-bottom: 1px solid var(--border-soft);
   background: var(--surface-1);
   color: var(--text-primary);
-  font-size: 15px;
+  font-size: var(--text-sm);
   font-weight: 600;
+  line-height: var(--leading-tight);
   text-align: left;
   cursor: pointer;
 }
@@ -341,10 +345,10 @@
 
 #status-text {
   text-align: center;
-  margin: 10px 0;
+  margin: var(--space-2) 0;
   font-weight: 500;
   font-size: var(--helper-text-size);
-  min-height: 20px;
+  min-height: 18px;
   transition: all 0.3s ease;
 }
 
@@ -397,15 +401,15 @@
     justify-content: flex-start;
     overflow-x: auto;
     flex-wrap: nowrap;
-    padding: 6px;
-    gap: 6px;
-    margin-bottom: 6px;
+    padding: var(--space-1);
+    gap: var(--space-1);
+    margin-bottom: var(--space-1);
   }
 
   .quick-action-btn {
     flex: 0 0 auto;
-    font-size: 13px;
-    padding: 8px 10px;
+    font-size: var(--text-xs);
+    padding: var(--space-2);
   }
 
   .quick-action-label-desktop {
@@ -420,26 +424,26 @@
 #canvas-container {
     max-width: 100%;
     min-height: 250px;
-    margin: 15px auto;
+    margin: var(--space-3) auto;
   }
 
   .canvas-placeholder,
 #placeholder {
     font-size: 18px;
-    padding: 0 20px;
+    padding: 0 var(--space-5);
   }
 
   .editor-controls {
-    margin: 4px auto;
+    margin: var(--space-1) auto;
     max-width: 100%;
-    padding: 12px;
+    padding: var(--space-3);
     max-height: none;
   }
 
   .editor-sections {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: var(--space-2);
   }
 
   .editor-sections-nav {
@@ -451,7 +455,7 @@
   }
 
   .section-panel {
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     border: 1px solid var(--border-soft);
   }
 
@@ -470,17 +474,17 @@
 
 @media (max-width: 480px) {
   .quick-actions-bar {
-    top: 4px;
-    padding: 5px;
-    border-radius: 10px;
+    top: var(--space-1);
+    padding: var(--space-1);
+    border-radius: var(--radius-sm);
   }
 
   .quick-action-btn {
     min-width: 70px;
-    padding: 6px 8px;
-    gap: 5px;
-    border-radius: 8px;
-    font-size: 12px;
+    padding: var(--space-1) var(--space-2);
+    gap: var(--space-1);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-xs);
   }
 
   .quick-action-icon {

--- a/css/transforms.css
+++ b/css/transforms.css
@@ -4,32 +4,34 @@
 
 .panel-transforms,
 #transforms-panel {
-  padding: 20px;
-  margin-top: 15px;
+  padding: var(--space-4);
+  margin-top: var(--space-3);
 }
 
 #transforms-panel h3 {
-  margin: 0 0 15px;
+  margin: 0 0 var(--space-3);
   color: var(--text-primary);
   font-size: var(--section-title-size);
+  line-height: var(--leading-tight);
+  font-weight: 600;
 }
 
 .transform-buttons {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-2);
 }
 
 .button-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 10px;
+  gap: var(--space-2);
 }
 
 .btn-transform {
   flex-direction: column;
-  gap: 6px;
-  padding: 15px 10px;
+  gap: var(--space-1);
+  padding: var(--space-3) var(--space-2);
   position: relative;
   overflow: hidden;
 }
@@ -48,12 +50,12 @@
 .btn-transform:hover::before { left: 100%; }
 
 .btn-transform:hover {
-  transform: translateY(-3px) scale(1.05);
-  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.16);
 }
 
 .btn-transform:active {
-  transform: translateY(-1px) scale(1.02);
+  transform: translateY(0);
   box-shadow: 0 3px 10px color-mix(in srgb, var(--accent) 35%, transparent);
 }
 
@@ -66,16 +68,17 @@
 }
 
 .btn-icon {
-  font-size: 28px;
+  font-size: 24px;
   line-height: 1;
-  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.2));
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.18));
 }
 
 .btn-label {
-  font-size: var(--helper-text-size);
+  font-size: var(--text-xs);
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  line-height: var(--leading-tight);
 }
 
 @keyframes bounceIn {
@@ -104,17 +107,17 @@
 .btn-transform:active .btn-icon { animation: rotate-animation 0.5s ease; }
 
 @media (max-width: 768px) {
-  #transforms-panel { padding: 15px; }
-  .btn-transform { padding: 12px 8px; gap: 4px; }
-  .btn-icon { font-size: 24px; }
-  .btn-label { font-size: 11px; }
+  #transforms-panel { padding: var(--space-3); }
+  .btn-transform { padding: var(--space-2) var(--space-2); gap: var(--space-1); }
+  .btn-icon { font-size: 22px; }
+  .btn-label { font-size: var(--text-xs); }
 }
 
 @media (max-width: 480px) {
-  .button-row { gap: 8px; }
-  .btn-transform { padding: 10px 6px; }
-  .btn-icon { font-size: 22px; }
-  .btn-label { font-size: 10px; letter-spacing: 0.3px; }
+  .button-row { gap: var(--space-2); }
+  .btn-transform { padding: var(--space-2) var(--space-1); }
+  .btn-icon { font-size: 20px; }
+  .btn-label { font-size: var(--text-xs); letter-spacing: 0.01em; }
 }
 
 .btn-transform.active {

--- a/style.css
+++ b/style.css
@@ -1,4 +1,15 @@
 :root {
+  /* Typography scale */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.375rem;
+
+  --leading-tight: 1.2;
+  --leading-base: 1.4;
+  --leading-relaxed: 1.55;
+
   /* Semantic color tokens */
   --surface-1: #f6f8fb;
   --surface-2: #ffffff;
@@ -35,12 +46,14 @@
   --space-4: 16px;
   --space-5: 20px;
   --space-6: 24px;
+  --space-7: 32px;
+  --space-8: 40px;
 
   --font-family-base: 'Poppins', sans-serif;
-  --font-size-body: 14px;
-  --font-size-title: 1.4rem;
-  --font-size-section: 1.05rem;
-  --font-size-helper: 0.85rem;
+  --font-size-body: var(--text-sm);
+  --font-size-title: var(--text-xl);
+  --font-size-section: var(--text-md);
+  --font-size-helper: var(--text-xs);
 
   /* Backward-compatible aliases */
   --bg-surface: var(--surface-1);
@@ -58,6 +71,8 @@
 
 body {
   font-family: var(--font-family-base);
+  font-size: var(--font-size-body);
+  line-height: var(--leading-base);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -69,8 +84,9 @@ body {
 
 h1 {
   font-size: var(--font-size-title);
+  line-height: var(--leading-tight);
   color: var(--text-primary);
-  margin-bottom: 15px;
+  margin-bottom: var(--space-4);
 }
 
 .icon {
@@ -105,7 +121,7 @@ h1 {
 
 .card {
   background: var(--surface-2);
-  padding: clamp(20px, 2.4vw, 32px);
+  padding: clamp(var(--space-5), 2.4vw, var(--space-7));
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
   text-align: center;
@@ -115,15 +131,15 @@ h1 {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-3);
 }
 
 .workspace {
   display: grid;
   grid-template-columns: minmax(0, 1.75fr) minmax(300px, 0.9fr);
-  gap: clamp(16px, 2vw, 28px);
+  gap: clamp(var(--space-4), 2vw, 28px);
   align-items: start;
-  margin-top: 16px;
+  margin-top: var(--space-4);
 }
 
 .canvas-panel {
@@ -134,7 +150,7 @@ h1 {
 }
 
 .workspace-canvas-stage {
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .workspace-tools {
@@ -143,7 +159,7 @@ h1 {
   border-radius: var(--radius-md);
   background: var(--surface-2);
   box-shadow: var(--shadow-sm);
-  padding: 10px;
+  padding: var(--space-3);
 }
 
 .workspace-tools-toggle {
@@ -151,11 +167,13 @@ h1 {
   list-style: none;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   font-weight: 600;
   color: var(--text-primary);
-  padding: 6px 8px 10px;
+  padding: var(--space-2) var(--space-2) var(--space-3);
   text-align: left;
+  font-size: var(--text-sm);
+  line-height: var(--leading-tight);
 }
 
 .workspace-tools-toggle::-webkit-details-marker {
@@ -168,7 +186,7 @@ h1 {
   align-items: center;
   justify-content: center;
   gap: var(--space-2);
-  padding: 10px 16px;
+  padding: var(--space-2) var(--space-4);
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-default);
   background: var(--surface-1);
@@ -176,6 +194,7 @@ h1 {
   font-family: var(--font-family-base);
   font-weight: 600;
   font-size: var(--font-size-body);
+  line-height: var(--leading-tight);
   cursor: pointer;
   box-shadow: var(--shadow-sm);
   transition: all 0.25s ease;
@@ -232,13 +251,14 @@ h1 {
 
 .input {
   width: 100%;
-  padding: 10px 12px;
+  padding: var(--space-2) var(--space-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   background: var(--surface-2);
   color: var(--text-primary);
   font-family: var(--font-family-base);
   font-size: var(--font-size-body);
+  line-height: var(--leading-base);
   box-sizing: border-box;
   transition: all 0.25s ease;
 }


### PR DESCRIPTION
### Motivation
- Unificar la tipografía y spacing para evitar valores ad-hoc y facilitar ajustes de densidad visual en la UI. 
- Reducir la agresividad visual de los botones de transformaciones y hacer controles más compactos para mejorar el equilibrio en paneles y encabezados. 
- Hacer responsive y consistente el espaciado y tamaños en editor y herramientas para mantener coherencia en desktop y mobile.

### Description
- Se añadió una escala tipográfica en `:root` con `--text-xs` a `--text-xl` y line-heights `--leading-tight`, `--leading-base` y `--leading-relaxed`, y se vinculó la semántica (`--font-size-*`) a esta escala en `style.css`.
- Se extendió la escala de spacing (`--space-7`, `--space-8`) y se reemplazaron muchos valores ad-hoc por tokens de spacing en `style.css`, `css/editor.css` y `css/transforms.css` para uniformizar paddings, gaps y márgenes.
- Se moderó la apariencia de los botones de transformaciones en `css/transforms.css` reduciendo la escala/elevación en hover/active, bajando tamaños de iconos, quitando `text-transform: uppercase` y usando `letter-spacing` más sutil.
- Se ajustó la densidad del editor en `css/editor.css` haciendo quick-actions, pestañas y headings más compactos y aplicando las variables de line-height y spacing para un balance más sobrio entre paneles.

### Testing
- Ejecutado `git diff --check` para verificar problemas de formato y conflictos y no se reportaron errores. 
- Comprobado el estado de cambios con `git status --short` para confirmar los ficheros modificados (`style.css`, `css/editor.css`, `css/transforms.css`). 
- No se encontraron advertencias de sintaxis CSS en las ediciones realizadas con las herramientas disponibles en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb64cb0e988331a7d96c905caa121c)