### PR TITLE
Improve accessibility across editor panels and controls

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -66,12 +66,13 @@
 }
 
 .quick-action-btn-secondary {
-  opacity: 0.72;
-  font-weight: 500;
+  opacity: 0.92;
+  color: var(--text-primary);
+  font-weight: 600;
 }
 
 .quick-action-btn-secondary .quick-action-label-desktop {
-  opacity: 0.86;
+  opacity: 1;
 }
 
 .quick-action-btn-secondary:hover,
@@ -232,7 +233,7 @@
   width: 100%;
   border: 1px solid var(--border-default);
   background: var(--surface-2);
-  color: var(--text-secondary);
+  color: var(--text-primary);
   border-radius: var(--radius-sm);
   padding: var(--space-2) var(--space-3);
   font-size: var(--text-xs);

--- a/index.html
+++ b/index.html
@@ -26,14 +26,14 @@
     <input type="file" id="fileInput" accept="image/*">
 
     <!-- Barra de Progreso -->
-    <div id="progress-container" style="display: none;">
-      <div id="progress-bar"></div>
+    <div id="progress-container" style="display: none;" aria-hidden="true">
+      <div id="progress-bar" role="progressbar" aria-label="Progreso de carga" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
     </div>
-    <div id="status-text"></div>
+    <div id="status-text" role="status" aria-live="polite" aria-atomic="true"></div>
 
     <div class="workspace">
       <div class="canvas-panel workspace-canvas-stage">
-        <div class="quick-actions-bar" id="quickActionsBar" aria-label="Acciones rápidas del editor">
+        <div class="quick-actions-bar" id="quickActionsBar" role="toolbar" aria-label="Acciones rápidas del editor">
           <button id="quick-download" class="quick-action-btn quick-action-btn-primary" type="button" title="Exportar imagen editada">
             <span class="quick-action-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 4v11"></path><path d="m7 11 5 5 5-5"></path><path d="M5 20h14"></path></svg></span>
             <span class="quick-action-label quick-action-label-desktop">Exportar</span>
@@ -69,33 +69,33 @@
         <summary class="workspace-tools-toggle"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><rect x="3" y="7" width="18" height="12" rx="2"></rect><path d="M9 7V5h6v2"></path><path d="M3 12h18"></path></svg></span> Herramientas</summary>
 
       <!-- Panel de controles del editor (se mostrará cuando haya imagen) -->
-      <div class="editor-controls" id="editorControls" style="display: none;">
-        <div class="editor-sections" id="editorSections">
+      <div class="editor-controls" id="editorControls" style="display: none;" aria-hidden="true">
+        <div class="editor-sections" id="editorSections" aria-live="polite">
           <div class="editor-sections-nav" role="tablist" aria-label="Secciones del editor">
-            <button class="editor-section-tab active" type="button" role="tab" aria-selected="true" aria-controls="filters-panel" data-target="filters-panel">
+            <button id="tab-filters" class="editor-section-tab active" type="button" role="tab" aria-selected="true" aria-controls="filters-panel" tabindex="0" data-target="filters-panel">
               <span class="editor-tab-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="8" cy="9" r="2"></circle><circle cx="14" cy="7" r="2"></circle><circle cx="17" cy="12" r="2"></circle><path d="M12 20a8 8 0 1 1 0-16h1a3 3 0 0 1 0 6h-1a3 3 0 1 0 0 6Z"></path></svg></span>
               <span class="editor-tab-text">Filtros</span>
             </button>
-            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="transforms-panel" data-target="transforms-panel">
+            <button id="tab-transforms" class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="transforms-panel" tabindex="-1" data-target="transforms-panel">
               <span class="editor-tab-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M21 4v6h-6"></path><path d="M3 20v-6h6"></path><path d="M20 10a8 8 0 0 0-14-3"></path><path d="M4 14a8 8 0 0 0 14 3"></path></svg></span>
               <span class="editor-tab-text">Ajustar</span>
             </button>
-            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="export-panel" data-target="export-panel">
+            <button id="tab-export" class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="export-panel" tabindex="-1" data-target="export-panel">
               <span class="editor-tab-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3v11"></path><path d="m7 10 5 5 5-5"></path><path d="M4 19h16"></path></svg></span>
               <span class="editor-tab-text">Exportar</span>
             </button>
-            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="comparison-panel" data-target="comparison-panel">
+            <button id="tab-comparison" class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="comparison-panel" tabindex="-1" data-target="comparison-panel">
               <span class="editor-tab-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 4v16"></path><path d="M5 8h14"></path><path d="m8 8-3 5h6l-3-5Z"></path><path d="m16 8-3 5h6l-3-5Z"></path></svg></span>
               <span class="editor-tab-text">Comparar</span>
             </button>
-            <button class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="crop-panel" data-target="crop-panel">
+            <button id="tab-crop" class="editor-section-tab" type="button" role="tab" aria-selected="false" aria-controls="crop-panel" tabindex="-1" data-target="crop-panel">
               <span class="editor-tab-icon icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2"></circle><circle cx="6" cy="18" r="2"></circle><path d="M20 4 8 16"></path><path d="m8 8 12 12"></path></svg></span>
               <span class="editor-tab-text">Recortar</span>
             </button>
           </div>
 
       <!-- Panel de Filtros -->
-      <div id="filters-panel" class="controls-section section-panel panel panel-filters active" data-section="filters-panel">
+      <div id="filters-panel" class="controls-section section-panel panel panel-filters active" data-section="filters-panel" role="tabpanel" aria-labelledby="tab-filters" aria-hidden="false">
         <button class="section-accordion-trigger" type="button" aria-expanded="true" aria-controls="filters-panel-body" data-target="filters-panel"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="8" cy="9" r="2"></circle><circle cx="14" cy="7" r="2"></circle><circle cx="17" cy="12" r="2"></circle><path d="M12 20a8 8 0 1 1 0-16h1a3 3 0 0 1 0 6h-1a3 3 0 1 0 0 6Z"></path></svg></span> Filtros</button>
         <div class="section-panel-body" id="filters-panel-body">
 
@@ -105,7 +105,7 @@
             <span class="filter-name">Brillo</span>
             <span class="filter-value" id="brightness-value">100</span>
           </div>
-          <input type="range" id="brightness" class="range" min="0" max="200" value="100" step="1">
+          <input type="range" id="brightness" class="range" min="0" max="200" value="100" step="1" aria-label="Control de brillo">
         </div>
 
         <!-- Contraste -->
@@ -114,7 +114,7 @@
             <span class="filter-name">Contraste</span>
             <span class="filter-value" id="contrast-value">100</span>
           </div>
-          <input type="range" id="contrast" class="range" min="0" max="200" value="100" step="1">
+          <input type="range" id="contrast" class="range" min="0" max="200" value="100" step="1" aria-label="Control de contraste">
         </div>
 
         <!-- Saturación -->
@@ -123,7 +123,7 @@
             <span class="filter-name">Saturación</span>
             <span class="filter-value" id="saturation-value">100</span>
           </div>
-          <input type="range" id="saturation" class="range" min="0" max="200" value="100" step="1">
+          <input type="range" id="saturation" class="range" min="0" max="200" value="100" step="1" aria-label="Control de saturación">
         </div>
 
         <!-- Desenfoque -->
@@ -132,7 +132,7 @@
             <span class="filter-name">Desenfoque</span>
             <span class="filter-value" id="blur-value">0px</span>
           </div>
-          <input type="range" id="blur" class="range" min="0" max="10" value="0" step="0.5">
+          <input type="range" id="blur" class="range" min="0" max="10" value="0" step="0.5" aria-label="Control de desenfoque">
         </div>
 
         <!-- Escala de Grises -->
@@ -141,7 +141,7 @@
             <span class="filter-name">Blanco y negro</span>
             <span class="filter-value" id="grayscale-value">0%</span>
           </div>
-          <input type="range" id="grayscale" class="range" min="0" max="100" value="0" step="1">
+          <input type="range" id="grayscale" class="range" min="0" max="100" value="0" step="1" aria-label="Control de blanco y negro">
         </div>
 
         <!-- Botón Resetear -->
@@ -150,7 +150,7 @@
       </div>
 
       <!-- Panel de Transformaciones -->
-      <div id="transforms-panel" class="controls-section section-panel panel panel-transforms" data-section="transforms-panel">
+      <div id="transforms-panel" class="controls-section section-panel panel panel-transforms" data-section="transforms-panel" role="tabpanel" aria-labelledby="tab-transforms" aria-hidden="true" hidden>
         <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="transforms-panel-body" data-target="transforms-panel"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M21 4v6h-6"></path><path d="M3 20v-6h6"></path><path d="M20 10a8 8 0 0 0-14-3"></path><path d="M4 14a8 8 0 0 0 14 3"></path></svg></span> Ajustar</button>
         <div class="section-panel-body" id="transforms-panel-body">
 
@@ -183,7 +183,7 @@
       </div>
 
       <!-- Panel de Exportación -->
-      <div id="export-panel" class="controls-section section-panel panel panel-export" data-section="export-panel">
+      <div id="export-panel" class="controls-section section-panel panel panel-export" data-section="export-panel" role="tabpanel" aria-labelledby="tab-export" aria-hidden="true" hidden>
         <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="export-panel-body" data-target="export-panel"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3v11"></path><path d="m7 10 5 5 5-5"></path><path d="M4 19h16"></path></svg></span> Exportar</button>
         <div class="section-panel-body" id="export-panel-body">
 
@@ -237,28 +237,28 @@
       </div>
 
       <!-- Panel de Comparación -->
-      <div id="comparison-panel" class="controls-section section-panel panel panel-comparison" data-section="comparison-panel">
+      <div id="comparison-panel" class="controls-section section-panel panel panel-comparison" data-section="comparison-panel" role="tabpanel" aria-labelledby="tab-comparison" aria-hidden="true" hidden>
         <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="comparison-panel-body" data-target="comparison-panel"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 4v16"></path><path d="M5 8h14"></path><path d="m8 8-3 5h6l-3-5Z"></path><path d="m16 8-3 5h6l-3-5Z"></path></svg></span> Comparar</button>
         <div class="section-panel-body" id="comparison-panel-body">
 
         <!-- Botón de toggle comparación -->
-        <button id="toggle-comparison" class="btn-comparison btn btn-secondary btn-toggle-comparison">
+        <button id="toggle-comparison" class="btn-comparison btn btn-secondary btn-toggle-comparison" aria-pressed="false" aria-controls="split-view-control" aria-expanded="false">
           <span class="btn-icon icon icon-md" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6Z"></path><circle cx="12" cy="12" r="3"></circle></svg></span>
           <span class="btn-text">Comparar</span>
         </button>
 
         <!-- Control de vista dividida -->
-        <div id="split-view-control" class="hidden">
+        <div id="split-view-control" class="hidden" aria-hidden="true">
           <!-- Checkbox para activar split view -->
           <label class="split-toggle">
-            <input type="checkbox" id="split-mode-toggle">
+            <input type="checkbox" id="split-mode-toggle" aria-controls="split-slider-container" aria-expanded="false">
             <span>Vista dividida (antes/después)</span>
           </label>
 
           <!-- Slider divisor -->
-          <div id="split-slider-container" style="display: none;">
+          <div id="split-slider-container" style="display: none;" aria-hidden="true">
             <div id="split-slider-value">50%</div>
-            <input type="range" id="split-slider" class="range" min="0" max="100" value="50" step="1">
+            <input type="range" id="split-slider" class="range" min="0" max="100" value="50" step="1" aria-label="Posición de comparación dividida">
             <div class="split-labels">
               <span>Original</span>
               <span>Editada</span>
@@ -269,7 +269,7 @@
       </div>
 
       <!-- Panel de Recorte -->
-      <div id="crop-panel" class="controls-section section-panel panel panel-crop" data-section="crop-panel">
+      <div id="crop-panel" class="controls-section section-panel panel panel-crop" data-section="crop-panel" role="tabpanel" aria-labelledby="tab-crop" aria-hidden="true" hidden>
         <button class="section-accordion-trigger" type="button" aria-expanded="false" aria-controls="crop-panel-body" data-target="crop-panel"><span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2"></circle><circle cx="6" cy="18" r="2"></circle><path d="M20 4 8 16"></path><path d="m8 8 12 12"></path></svg></span> Recortar</button>
         <div class="section-panel-body" id="crop-panel-body">
 
@@ -288,13 +288,13 @@
 
         <!-- Botones de recorte -->
         <div class="crop-buttons">
-          <button id="start-crop" class="btn btn-secondary btn-start-crop">
+          <button id="start-crop" class="btn btn-secondary btn-start-crop" aria-controls="crop-actions crop-instructions" aria-expanded="false">
             <span class="btn-icon icon icon-md" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2"></circle><circle cx="6" cy="18" r="2"></circle><path d="M20 4 8 16"></path><path d="m8 8 12 12"></path></svg></span>
             <span>Recortar</span>
           </button>
 
           <!-- Botones de acción (visibles durante recorte) -->
-          <div class="crop-action-buttons" id="crop-actions">
+          <div class="crop-action-buttons" id="crop-actions" aria-hidden="true">
             <button id="apply-crop" class="btn btn-primary btn-apply-crop">
               <span class="icon icon-sm" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="m5 12 4 4 10-10"></path></svg></span>
               <span>Aplicar</span>
@@ -307,7 +307,7 @@
         </div>
 
         <!-- Instrucciones de uso -->
-        <div class="crop-instructions" id="crop-instructions">
+        <div class="crop-instructions" id="crop-instructions" aria-hidden="true">
           <p><strong>Instrucciones:</strong></p>
           <p>• Arrastra para crear el área de recorte</p>
           <p>• Mueve el área haciendo clic dentro</p>

--- a/js/main.js
+++ b/js/main.js
@@ -171,6 +171,28 @@ function setupEditorSectionNavigation() {
       const targetId = tab.dataset.target;
       setActiveEditorSection(targetId);
     });
+
+    tab.addEventListener('keydown', (event) => {
+      if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+      event.preventDefault();
+      const tabs = Array.from(editorSectionTabs);
+      const currentIndex = tabs.indexOf(tab);
+      const isHorizontal = ['ArrowLeft', 'ArrowRight'].includes(event.key);
+      const isVertical = ['ArrowUp', 'ArrowDown'].includes(event.key);
+
+      if (!isHorizontal && !isVertical && !['Home', 'End'].includes(event.key)) return;
+
+      let nextIndex = currentIndex;
+      if (event.key === 'Home') nextIndex = 0;
+      if (event.key === 'End') nextIndex = tabs.length - 1;
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') nextIndex = (currentIndex + 1) % tabs.length;
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+
+      const nextTab = tabs[nextIndex];
+      if (!nextTab) return;
+      setActiveEditorSection(nextTab.dataset.target);
+      nextTab.focus();
+    });
   });
 
   editorSectionAccordionTriggers.forEach((trigger) => {
@@ -194,12 +216,15 @@ function setActiveEditorSection(sectionId) {
   editorSectionPanels.forEach((panel) => {
     const isActive = panel.id === sectionId;
     panel.classList.toggle('active', isActive);
+    panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+    panel.toggleAttribute('hidden', !isActive);
   });
 
   editorSectionTabs.forEach((tab) => {
     const isActive = tab.dataset.target === sectionId;
     tab.classList.toggle('active', isActive);
     tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    tab.setAttribute('tabindex', isActive ? '0' : '-1');
   });
 
   editorSectionAccordionTriggers.forEach((trigger) => {
@@ -441,16 +466,21 @@ function setupComparisonListeners() {
       if (isComparing) {
         toggleBtn.classList.add('active');
         toggleBtn.querySelector('.btn-text').textContent = 'Ver Editada';
+        toggleBtn.setAttribute('aria-pressed', 'true');
+        toggleBtn.setAttribute('aria-expanded', 'true');
         canvasContainer.classList.add('comparing');
         quickCompareBtn?.classList.add('active');
 
         // Mostrar controles de split view
         if (splitViewControl) {
           splitViewControl.classList.remove('hidden');
+          splitViewControl.setAttribute('aria-hidden', 'false');
         }
       } else {
         toggleBtn.classList.remove('active');
         toggleBtn.querySelector('.btn-text').textContent = 'Ver Original';
+        toggleBtn.setAttribute('aria-pressed', 'false');
+        toggleBtn.setAttribute('aria-expanded', 'false');
         canvasContainer.classList.remove('comparing');
         canvasContainer.classList.remove('split-view');
         quickCompareBtn?.classList.remove('active');
@@ -458,6 +488,7 @@ function setupComparisonListeners() {
         // Ocultar controles de split view
         if (splitViewControl) {
           splitViewControl.classList.add('hidden');
+          splitViewControl.setAttribute('aria-hidden', 'true');
         }
 
         // Resetear split mode
@@ -466,6 +497,7 @@ function setupComparisonListeners() {
         }
         if (splitSliderContainer) {
           splitSliderContainer.style.display = 'none';
+          splitSliderContainer.setAttribute('aria-hidden', 'true');
         }
       }
     });
@@ -485,7 +517,9 @@ function setupComparisonListeners() {
         // Mostrar slider
         if (splitSliderContainer) {
           splitSliderContainer.style.display = 'block';
+          splitSliderContainer.setAttribute('aria-hidden', 'false');
         }
+        splitModeToggle.setAttribute('aria-expanded', 'true');
       } else {
         // Desactivar modo split, volver a toggle
         imageComparison.exitSplitMode();
@@ -495,7 +529,9 @@ function setupComparisonListeners() {
         // Ocultar slider
         if (splitSliderContainer) {
           splitSliderContainer.style.display = 'none';
+          splitSliderContainer.setAttribute('aria-hidden', 'true');
         }
+        splitModeToggle.setAttribute('aria-expanded', 'false');
       }
     });
   }
@@ -544,12 +580,15 @@ function setupCropListeners() {
         startCropBtn.style.display = 'none';
         if (cropActions) {
           cropActions.classList.add('active');
+          cropActions.setAttribute('aria-hidden', 'false');
         }
 
         // Mostrar instrucciones
         if (cropInstructions) {
           cropInstructions.classList.add('active');
+          cropInstructions.setAttribute('aria-hidden', 'false');
         }
+        startCropBtn.setAttribute('aria-expanded', 'true');
 
         // Agregar clase al canvas container
         canvasContainer.classList.add('crop-active');
@@ -633,12 +672,15 @@ function exitCropMode() {
   }
   if (cropActions) {
     cropActions.classList.remove('active');
+    cropActions.setAttribute('aria-hidden', 'true');
   }
 
   // Ocultar instrucciones
   if (cropInstructions) {
     cropInstructions.classList.remove('active');
+    cropInstructions.setAttribute('aria-hidden', 'true');
   }
+  startCropBtn?.setAttribute('aria-expanded', 'false');
 
   // Remover clase del canvas container
   canvasContainer.classList.remove('crop-active');
@@ -771,6 +813,8 @@ function handleClearImage() {
   if (toggleBtn) {
     toggleBtn.classList.remove('active');
     toggleBtn.querySelector('.btn-text').textContent = 'Ver Original';
+    toggleBtn.setAttribute('aria-pressed', 'false');
+    toggleBtn.setAttribute('aria-expanded', 'false');
   }
   quickCompareBtn?.classList.remove('active');
 
@@ -838,6 +882,7 @@ function simulateProgress() {
 function updateProgress(percent) {
   if (progressBar) {
     progressBar.style.width = `${percent}%`;
+    progressBar.setAttribute('aria-valuenow', String(percent));
   }
   if (statusText && percent < 100) {
     statusText.textContent = `Cargando ${percent}%`;
@@ -850,7 +895,9 @@ function updateProgress(percent) {
 function showProgress() {
   if (progressContainer) {
     progressContainer.style.display = 'block';
+    progressContainer.setAttribute('aria-hidden', 'false');
     progressBar.style.width = '0%';
+    progressBar.setAttribute('aria-valuenow', '0');
   }
 }
 
@@ -860,6 +907,7 @@ function showProgress() {
 function hideProgress() {
   if (progressContainer) {
     progressContainer.style.display = 'none';
+    progressContainer.setAttribute('aria-hidden', 'true');
   }
 }
 
@@ -915,6 +963,7 @@ function hidePlaceholder() {
 function showEditorControls() {
   if (editorControls) {
     editorControls.style.display = 'block';
+    editorControls.setAttribute('aria-hidden', 'false');
   }
 }
 
@@ -924,5 +973,6 @@ function showEditorControls() {
 function hideEditorControls() {
   if (editorControls) {
     editorControls.style.display = 'none';
+    editorControls.setAttribute('aria-hidden', 'true');
   }
 }

--- a/style.css
+++ b/style.css
@@ -17,7 +17,7 @@
   --surface-overlay: color-mix(in srgb, var(--surface-2) 92%, transparent);
 
   --text-primary: #1f2937;
-  --text-secondary: #6b7280;
+  --text-secondary: #475569;
   --text-inverse: #ffffff;
 
   --accent: #ff6600;
@@ -28,11 +28,12 @@
   --success: #22c55e;
   --info: #2196f3;
 
-  --border-default: #dbe1ea;
+  --border-default: #c8d3e0;
   --border-strong: #c6ced9;
   --border-soft: #ececec;
 
-  --focus-ring: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent);
+  --focus-ring: 0 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent);
+  --focus-outline: 2px solid color-mix(in srgb, var(--accent) 70%, #000 30%);
 
   --radius-sm: 8px;
   --radius-md: 12px;
@@ -206,10 +207,19 @@ h1 {
   color: var(--accent);
 }
 
-.btn:focus-visible,
-.input:focus-visible,
-.range:focus-visible {
-  outline: none;
+
+:where(
+  .btn,
+  .quick-action-btn,
+  .editor-section-tab,
+  .section-accordion-trigger,
+  button,
+  input,
+  select,
+  .range
+):focus-visible {
+  outline: var(--focus-outline);
+  outline-offset: 2px;
   box-shadow: var(--focus-ring);
 }
 
@@ -369,5 +379,50 @@ input[type="file"] {
 
   .workspace-canvas-stage {
     order: 1;
+  }
+}
+
+
+/* Reduced motion and accessibility */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .btn:hover,
+  .canvas-container:hover,
+  .btn-transform:hover,
+  .btn-download:hover {
+    transform: none !important;
+  }
+}
+
+@media (max-width: 900px) {
+  :where(
+    .btn,
+    .quick-action-btn,
+    .editor-section-tab,
+    .section-accordion-trigger,
+    .split-toggle input[type="checkbox"],
+    .input,
+    select,
+    input[type="range"]
+  ) {
+    min-height: 44px;
+  }
+
+  :where(.btn, .quick-action-btn, .editor-section-tab, .section-accordion-trigger) {
+    min-width: 44px;
+  }
+
+  .range::-webkit-slider-thumb,
+  .range::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
   }
 }


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad y la navegación del editor adaptando contraste, foco, movimiento y metas táctiles para cumplir buenas prácticas de accesibilidad.
- Añadir atributos ARIA y estados dinámicos para que las secciones y controles dinámicos sean operables y anunciables por tecnologías de asistencia.

### Description
- Ajusté tokens en `style.css` para mejorar contraste y reforzar el tratamiento de foco (`--text-secondary`, `--border-default`, `--focus-ring`, `--focus-outline`) y añadí reglas globales de `:focus-visible` para botones, tabs, inputs, selects y sliders.
- Incorporé `@media (prefers-reduced-motion: reduce)` para desactivar animaciones/transformaciones no esenciales y añadí reglas móviles que elevan objetivos táctiles a un mínimo de 44px y agrandan thumbs de sliders; cambios principales en `style.css` y `css/editor.css` (mejora de contraste en acciones secundarias y tabs).
- Añadí atributos ARIA y mejoras semánticas en `index.html` (rol `progressbar`, `role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6a8a01f48331a054c0178d3733e9)